### PR TITLE
bugfix: illegal iterator in vs2019 debug mode

### DIFF
--- a/code/fast_trimesh.cpp
+++ b/code/fast_trimesh.cpp
@@ -710,8 +710,9 @@ inline void FastTrimesh::splitEdge(const uint  &e_id, uint v_id)
     uint ev0_id = edges[e_id].v.first;
     uint ev1_id = edges[e_id].v.second;
 
-    for(uint t_id : e2t[e_id])
+    for(int i=0; i < e2t[e_id].size(); i++)
     {
+        uint t_id = e2t[e_id][i];
         uint v_opp = triVertOppositeTo(t_id, ev0_id, ev1_id);
         if(triVertsAreCCW(t_id, ev0_id, ev1_id)) std::swap(ev0_id, ev1_id);
 


### PR DESCRIPTION
I encountered an invalid iterator when I tested mesh arrangement code on large triangles.  I carefully checked the code in Line 713 of fast_trimesh.cpp and suspected the bug is caused by invalid iterator in this range-for loop. e2t.emplace_back() is called by addTri --> addEdge function in this for loop, so the reallocation of e2t occured which make the range-for-loop fail. This could probably be the reason of this bug. I tried to fix this bug by using index to access. 